### PR TITLE
remove static namespace

### DIFF
--- a/__sdk__.js
+++ b/__sdk__.js
@@ -2,10 +2,7 @@
 /* eslint import/no-commonjs: 0 */
 
 module.exports = {
-
     'legal': {
-        entry: './src/index',
-        
-        staticNamespace: '__legal__'
+        entry: './src/index'
     }
 };


### PR DESCRIPTION
we removed the ability to set static namespaces from clientsdknodeweb last year, cleaning up stragglers